### PR TITLE
refactor unit tests to use ORM

### DIFF
--- a/tests/fileTests.py
+++ b/tests/fileTests.py
@@ -8,9 +8,9 @@ from boto.s3.key import Key
 from baseTest import BaseTest
 from testUtils import TestUtils
 from dataactcore.aws.s3UrlHandler import s3UrlHandler
-from dataactcore.models.jobModels import Status
+from dataactcore.models.jobModels import Submission, JobStatus
+from dataactcore.models.errorModels import ErrorData, FileStatus
 from dataactbroker.handlers.fileHandler import FileHandler
-from dataactbroker.handlers.interfaceHolder import InterfaceHolder
 
 class FileTests(BaseTest):
     """ Test file submission routes """
@@ -42,26 +42,32 @@ class FileTests(BaseTest):
             self.tablesCleared = True
             open(self.TABLES_CLEARED_FILE,"w").write(str(True))
             # Create submission ID
-            submissionResponse = jobTracker.runStatement("INSERT INTO submission (datetime_utc) VALUES (0) RETURNING submission_id")
-            submissionId = submissionResponse.fetchone()[0]
-            self.submissionId = submissionId
-            # Create jobs
-            sqlStatements = ["INSERT INTO job_status (file_type_id, status_id, type_id, submission_id) VALUES (1,4,1,"+str(submissionId)+") RETURNING job_id",
-                             "INSERT INTO job_status (file_type_id, status_id, type_id, submission_id) VALUES (1,3,2,"+str(submissionId)+") RETURNING job_id",
-                             "INSERT INTO job_status (file_type_id, status_id, type_id, submission_id) VALUES (1,1,5,"+str(submissionId)+") RETURNING job_id",
-                             "INSERT INTO job_status (file_type_id, status_id, type_id, submission_id) VALUES (2,2,2,"+str(submissionId)+") RETURNING job_id",
-                             "INSERT INTO job_status (file_type_id, status_id, type_id, submission_id) VALUES (3,2,2,"+str(submissionId)+") RETURNING job_id",
-                             "INSERT INTO job_status (file_type_id, status_id, type_id, submission_id) VALUES (4,2,2,"+str(submissionId)+") RETURNING job_id"]
+            self.submissionId = self.insertSubmission(self.jobTracker)
 
-            jobKeyList = ["uploadFinished","recordRunning","externalWaiting","awardFin","appropriations","procurement"]
-            index = 0
+            # Create jobs
+            jobValues = {}
+            jobValues["uploadFinished"] = [1,4,1]
+            jobValues["recordRunning"] = [1,3,2]
+            jobValues["externalWaiting"] = [1,1,5]
+            jobValues["awardFin"] = [2,2,2]
+            jobValues["appropriations"] = [3,2,2]
+            jobValues["procurement"] = [4,2,2]
             self.jobIdDict = {}
-            for statement in sqlStatements:
-                self.jobIdDict[jobKeyList[index]] = jobTracker.runStatement(statement).fetchone()[0]
-                index += 1
+
+            for jobKey, values in jobValues.items():
+                job_id = self.insertJob(
+                    self.jobTracker,
+                    filetype = values[0],
+                    status = values[1],
+                    type_id = values[2],
+                    submission = self.submissionId
+                )
+                self.jobIdDict[jobKey] = job_id
+
             # Save jobIdDict to file
             open(self.JOB_ID_FILE,"w").write(json.dumps(self.jobIdDict))
-            open(self.SUBMISSION_ID_FILE,"w").write(str(submissionId))
+            open(self.SUBMISSION_ID_FILE,"w").write(str(self.submissionId))
+
         else:
             # Read job ID dict from file
             self.jobIdDict = json.loads(open(self.JOB_ID_FILE,"r").read())
@@ -228,13 +234,31 @@ class FileTests(BaseTest):
         #setup the database for the route test
         submissionId = str(self.insertSubmission(self.jobTracker))
 
-        job = self.insertJob(self.jobTracker,"1","2","2",submissionId)
+        job = self.insertJob(
+            self.jobTracker,
+            filetype = "1",
+            status = "2",
+            type_id = "2",
+            submission = submissionId
+        )
         self.insertFileStatus(self.errorDatabase,str(job),"1") # Everything Is Fine
 
-        job = self.insertJob(self.jobTracker,"2","2","2",submissionId)
+        job = self.insertJob(
+            self.jobTracker,
+            filetype = "2",
+            status = "2",
+            type_id = "2",
+            submission = submissionId
+        )
         self.insertFileStatus(self.errorDatabase,str(job),"3") #Bad Header
 
-        job = self.insertJob(self.jobTracker,"3","2","2",submissionId)
+        job = self.insertJob(
+            self.jobTracker,
+            filetype = "3",
+            status = "2",
+            type_id = "2",
+            submission = submissionId
+        )
         self.insertFileStatus(self.errorDatabase,str(job),"1") # Validation level Errors
         self.insertRowLevelError(self.errorDatabase,str(job))
 
@@ -244,44 +268,73 @@ class FileTests(BaseTest):
         self.check_metrics(submissionId,True,"appropriations")
 
     @staticmethod
-    def insertSubmission(jobTracker):
+    def insertSubmission(jobTracker, submission = None):
         """ Insert one submission into job tracker and get submission ID back """
-        stmt = "INSERT INTO submission (datetime_utc) VALUES (0) RETURNING submission_id"
-        response = jobTracker.runStatement(stmt)
-        return response.fetchone()[0]
+        if submission:
+            sub = Submission(submission_id = submission, datetime_utc = 0)
+        else:
+            sub = Submission(datetime_utc = 0)
+        jobTracker.session.add(sub)
+        jobTracker.session.commit()
+        return sub.submission_id
 
     @staticmethod
-    def insertJob(jobTracker,filetype,status,type_id,submission):
+    def insertJob(jobTracker,filetype,status,type_id,submission, job_id = None):
         """ Insert one job into job tracker and get ID back """
-        stmt = "INSERT INTO job_status (file_type_id, status_id, type_id, submission_id)VALUES("+filetype+","+status+","+type_id+","+submission+") RETURNING job_id"
-        results = jobTracker.runStatement(stmt)
-        return results.fetchone()[0]
+        job = JobStatus(
+            file_type_id = filetype,
+            status_id = status,
+            type_id = type_id,
+            submission_id = submission
+        )
+        if job_id:
+            JobStatus.job_id = job_id
+        jobTracker.session.add(job)
+        jobTracker.session.commit()
+        return job.job_id
 
     @staticmethod
     def insertFileStatus(errorDB,job,status):
         """ Insert one file status into error database and get ID back """
-        stmt = "INSERT INTO file_status(job_id, filename, status_id) VALUES("+job+",' ',"+status+") RETURNING status_id"
-        response = errorDB.runStatement(stmt)
-        return response.fetchone()[0]
+        fs = FileStatus(
+            job_id = job,
+            filename = ' ',
+            status_id = status
+        )
+        errorDB.session.add(fs)
+        errorDB.session.commit()
+        return fs.file_id
 
     @staticmethod
     def insertRowLevelError(errorDB,job):
         """ Insert one error into error database """
-        stmt = "INSERT INTO error_data(job_id, filename, field_name, error_type_id, occurrences,first_row, rule_failed) VALUES ("+job+ ", 'test.csv', 'header 1', 1, 100, 123, 'Type Check' );"
-        errorDB.runStatement(stmt)
+        ed = ErrorData(
+            job_id = job,
+            filename = 'test.csv',
+            field_name = 'header 1',
+            error_type_id = 1,
+            occurrences = 100,
+            first_row = 123,
+            rule_failed = 'Type Check'
+        )
+        errorDB.session.add(ed)
+        errorDB.session.commit()
+        return ed.error_data_id
 
     def setupJobsForReports(self):
         """ Setting Jobs table to correct state for checking error reports from validator unit tests """
         #clearJobs()
-        self.tablesCleared = False
-        sqlStatements = [
-            "INSERT INTO submission (submission_id,datetime_utc) VALUES (11,0)",
-            "INSERT INTO job_status (job_id,file_type_id, status_id, type_id, submission_id) VALUES (11,1,4,2,11),(12,2,4,2,11),(13,3,4,2,11),(15,4,4,2,11)"
-        ]
-
         jobTracker = self.jobTracker
-        for statement in sqlStatements:
-            jobTracker.runStatement(statement)
+        self.tablesCleared = False
+        self.insertSubmission(jobTracker, 11)
+        self.insertJob(jobTracker,job_id = 11, filetype = 1,
+            status = 4, type_id = 2, submission = 11)
+        self.insertJob(jobTracker, job_id = 12, filetype = 2,
+            status = 4, type_id = 2, submission = 11)
+        self.insertJob(jobTracker, job_id = 13, filetype = 3,
+            status = 4, type_id = 2, submission = 11)
+        self.insertJob(jobTracker, job_id = 15, filetype = 4,
+            status = 4, type_id = 2, submission = 11)
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
This PR replaces SQL statements in the broker unit tests with the ORM:

* functionality of database operations is unchanged
* no additional changes made to the tests themselves

Note that at one test is failing locally due to Amazon authentication. I propose merging these ORM updates and opening another issue for additional unit test fixes/changes.