### PR TITLE
Fix to example in docs for correct rule error type

### DIFF
--- a/README.md
+++ b/README.md
@@ -529,7 +529,7 @@ Example output:
 	},
 	{
 	"field_name": "availabilitytypecode",
-	"error_name": "rule_error",
+	"error_name": "rule_failed",
 	"error_description": "",
 	"occurrences": 27,
 	"rule_failed": "Failed rule: Indicator must be X, F, A, or blank"


### PR DESCRIPTION
@nmonga91, @bsweger:  One line doc fix for rule_failed (which is the string we actually use) to replace rule_error (which I accidentally put in an example).