### PR TITLE
DB 376 alembic migration tweaks

### DIFF
--- a/dataactbroker/scripts/initialize.py
+++ b/dataactbroker/scripts/initialize.py
@@ -2,6 +2,7 @@ from dataactbroker.scripts.setupEmails import setupEmails
 from dataactcore.scripts.setupJobTrackerDB import setupJobTrackerDB
 from dataactcore.scripts.setupErrorDB import setupErrorDB
 from dataactcore.scripts.setupUserDB import setupUserDB
+from dataactcore.utils.responseException import ResponseException
 from dataactbroker.handlers.userHandler import UserHandler
 from dataactbroker.handlers.aws.session import SessionTable
 from dataactcore.config import CONFIG_BROKER, CONFIG_DB
@@ -51,9 +52,14 @@ def createAdmin():
     adminEmail = CONFIG_BROKER['admin_email']
     adminPass = CONFIG_BROKER['admin_password']
     userDb = UserHandler()
-    userDb.createUserWithPassword(adminEmail, adminPass, Bcrypt(), admin=True)
-    user = userDb.getUserByEmail(adminEmail)
-    userDb.addUserInfo(user, "Admin", "System", "System Admin")
+    try:
+        user = userDb.getUserByEmail(adminEmail)
+    except ResponseException as e:
+        if "no users" in e.message.lower():
+            userDb.createUserWithPassword(
+                adminEmail, adminPass, Bcrypt(), admin=True)
+            user = userDb.getUserByEmail(adminEmail)
+            userDb.addUserInfo(user, "Admin", "System", "System Admin")
     userDb.session.close()
 
 

--- a/dataactbroker/scripts/initialize.py
+++ b/dataactbroker/scripts/initialize.py
@@ -8,6 +8,7 @@ from dataactbroker.handlers.aws.session import SessionTable
 from dataactcore.config import CONFIG_BROKER, CONFIG_DB
 import argparse
 from flask.ext.bcrypt import Bcrypt
+from sqlalchemy.orm.exc import NoResultFound
 
 
 def options():
@@ -53,7 +54,7 @@ def createAdmin():
     try:
         user = userDb.getUserByEmail(adminEmail)
     except ResponseException as e:
-        if "no users" in e.message.lower():
+        if type(e.wrappedException) is NoResultFound:
             userDb.createUserWithPassword(
                 adminEmail, adminPass, Bcrypt(), admin=True)
             user = userDb.getUserByEmail(adminEmail)

--- a/dataactbroker/scripts/initialize.py
+++ b/dataactbroker/scripts/initialize.py
@@ -15,6 +15,7 @@ def options():
 
     parser = argparse.ArgumentParser()
     parser.add_argument("-i", "--initialize", action="store_true", help="Runs all of the setup options")
+    parser.add_argument("-a", "--createAdmin", action="store_true", help="Creates admin user")
     parser.add_argument("-s", "--start", action="store_true", help="Starts the broker")
     args = parser.parse_args()
     optionsDict = vars(args)
@@ -54,6 +55,7 @@ def createAdmin():
     try:
         user = userDb.getUserByEmail(adminEmail)
     except ResponseException as e:
+
         if type(e.wrappedException) is NoResultFound:
             userDb.createUserWithPassword(
                 adminEmail, adminPass, Bcrypt(), admin=True)

--- a/dataactbroker/scripts/initialize.py
+++ b/dataactbroker/scripts/initialize.py
@@ -14,8 +14,6 @@ def options():
 
     parser = argparse.ArgumentParser()
     parser.add_argument("-i", "--initialize", action="store_true", help="Runs all of the setup options")
-    parser.add_argument("-db", "--setupDB", action="store_true", help="Creates the database schema")
-    parser.add_argument("-a", "--createAdmin", action="store_true", help="Creates admin user")
     parser.add_argument("-s", "--start", action="store_true", help="Starts the broker")
     args = parser.parse_args()
     optionsDict = vars(args)
@@ -41,9 +39,9 @@ def initialize():
 
 
 def setupDB():
-    setupJobTrackerDB(hardReset=True)
-    setupErrorDB(True)
-    setupUserDB(True)
+    setupJobTrackerDB()
+    setupErrorDB()
+    setupUserDB()
     setupEmails()
 
 

--- a/tests/baseTest.py
+++ b/tests/baseTest.py
@@ -1,6 +1,7 @@
 import json
 import unittest
 import time
+import logging
 from random import randint
 from webtest import TestApp
 from dataactbroker.app import createApp
@@ -41,14 +42,18 @@ class BaseTest(unittest.TestCase):
             cls.num, suite)
         dataactcore.config.CONFIG_DB = config
 
-        # drop and re-create test user db/tables
-        setupUserDB(hardReset=True)
-        # drop and re-create test job db/tables
-        setupJobTrackerDB(hardReset=True)
-        # drop and re-create test error db/tables
-        setupErrorDB(hardReset=True)
+        # suppress INFO-level logging from Alembic migrations
+        logging.disable(logging.WARN)
+        # create test user db
+        setupUserDB()
+        # create test job db
+        setupJobTrackerDB()
+        # create test error db
+        setupErrorDB()
         # load e-mail templates
         setupEmails()
+        # reset logging defaults
+        logging.disable(logging.NOTSET)
 
         #get test users
         try:


### PR DESCRIPTION
Now that the [db setup scripts in core](https://github.com/fedspendingtransparency/data-act-core/tree/db-376-alembic-setup) use Alembic, a few corresponding changes to the broker:

* In broker init, only create the admin user if it doesn't already exist
* In broker init, remove old, unused args
* In broker unittests, suppress alembic informational messages so they don't obscure the test output